### PR TITLE
PHP 8+ Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "charcoal/object": "^5.0",
         "charcoal/property": "^5.0",
         "charcoal/translator": "^5.0",
-        "pimple/pimple": "^3.5"
+        "php-di/php-di": "^7.0"
     },
     "require-dev": {
         "charcoal/app": "^5.0",
@@ -38,7 +38,7 @@
         "phpunit/phpunit": "^9.5",
         "seld/jsonlint": "^1.10",
         "squizlabs/php_codesniffer": "^3.8",
-        "vimeo/psalm": "^5.17"
+        "vimeo/psalm": "^5.17 || ^6.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Charcoal/CookieConsent/CookieConsentModule.php
+++ b/src/Charcoal/CookieConsent/CookieConsentModule.php
@@ -4,6 +4,7 @@ namespace Charcoal\CookieConsent;
 
 use Charcoal\App\Module\AbstractModule;
 use Charcoal\App\Module\ModuleInterface;
+use Psr\Container\ContainerInterface;
 
 /**
  * Charcoal Module: Cookie Consent.
@@ -17,9 +18,9 @@ class CookieConsentModule extends AbstractModule implements ModuleInterface
 
     public function setUp(): self
     {
-        /** @var \Pimple\Container */
+        /** @var ContainerInterface */
         $container = $this->app()->getContainer();
-        $container->register(new CookieConsentServiceProvider());
+        (new CookieConsentServiceProvider())->register($container);
 
         return $this;
     }

--- a/src/Charcoal/CookieConsent/CookieConsentServiceProvider.php
+++ b/src/Charcoal/CookieConsent/CookieConsentServiceProvider.php
@@ -5,12 +5,16 @@ namespace Charcoal\CookieConsent;
 use Charcoal\CookieConsent\Model;
 use Charcoal\CookieConsent\Model\Repository;
 use Psr\Container\ContainerInterface;
+use DI\Container;
 
 /**
  * Service Provider: Cookie Consent.
  */
 class CookieConsentServiceProvider
 {
+    /**
+     * @param Container $container
+     */
     public function register(ContainerInterface $container)
     {
         /**

--- a/src/Charcoal/CookieConsent/CookieConsentServiceProvider.php
+++ b/src/Charcoal/CookieConsent/CookieConsentServiceProvider.php
@@ -4,64 +4,63 @@ namespace Charcoal\CookieConsent;
 
 use Charcoal\CookieConsent\Model;
 use Charcoal\CookieConsent\Model\Repository;
-use Pimple\Container;
-use Pimple\ServiceProviderInterface;
+use Psr\Container\ContainerInterface;
 
 /**
  * Service Provider: Cookie Consent.
  */
-class CookieConsentServiceProvider implements ServiceProviderInterface
+class CookieConsentServiceProvider
 {
-    public function register(Container $container)
+    public function register(ContainerInterface $container)
     {
         /**
          * @return array<string, class-string> The map of classes.
          */
-        $container['cookie-consent/class-map'] = function (): array {
+        $container->set('cookie-consent/class-map', function (): array {
             return [
                 'config/cookie-consent' => Config\CookieConsentConfig::class,
                 'config/plugin'         => Config\PluginConfig::class,
                 'model/category'        => Model\Category::class,
                 'model/disclosure'      => Model\Disclosure::class,
             ];
-        };
+        });
 
         /**
          * @return Repository\DisclosureRepository<Model\Disclosure>
          */
-        $container['cookie-consent/repository/disclosure'] = function (Container $container) {
-            $collectionLoader = $container['model/collection/loader'];
-            $collectionLoader->setModel($container['cookie-consent/class-map']['model/disclosure']);
+        $container->set('cookie-consent/repository/disclosure', function (ContainerInterface $container) {
+            $collectionLoader = $container->get('model/collection/loader');
+            $collectionLoader->setModel($container->get('cookie-consent/class-map')['model/disclosure']);
             $collectionLoader->setCollectionClass('array');
 
             return new Repository\DisclosureRepository($collectionLoader);
-        };
+        });
 
         /**
          * @return Repository\CategoryRepository<Model\Category>
          */
-        $container['cookie-consent/repository/category'] = function (Container $container) {
-            $collectionLoader = $container['model/collection/loader'];
-            $collectionLoader->setModel($container['cookie-consent/class-map']['model/category']);
+        $container->set('cookie-consent/repository/category', function (ContainerInterface $container) {
+            $collectionLoader = $container->get('model/collection/loader');
+            $collectionLoader->setModel($container->get('cookie-consent/class-map')['model/category']);
             $collectionLoader->setCollectionClass('array');
 
             return new Repository\CategoryRepository($collectionLoader);
-        };
+        });
 
         /**
          * @return Repository\LinkRelationRepository<\Charcoal\Model\Modelinterface>
          */
-        $container['cookie-consent/repository/link-relation'] = function (Container $container) {
-            $collectionLoader = $container['model/collection/loader'];
-            $collectionLoader->setModel($container['cookie-consent/config']->getPrivacyPolicyObjType());
+        $container->set('cookie-consent/repository/link-relation', function (ContainerInterface $container) {
+            $collectionLoader = $container->get('model/collection/loader');
+            $collectionLoader->setModel($container->get('cookie-consent/config')->getPrivacyPolicyObjType());
             $collectionLoader->setCollectionClass('array');
 
             return new Repository\LinkRelationRepository($collectionLoader);
-        };
+        });
 
-        $container['cookie-consent/config'] = function (Container $container) {
-            $appConfig    = $container['config'];
-            $cookieClass  = $container['cookie-consent/class-map']['config/cookie-consent'];
+        $container->set('cookie-consent/config', function (ContainerInterface $container) {
+            $appConfig    = $container->get('config');
+            $cookieClass  = $container->get('cookie-consent/class-map')['config/cookie-consent'];
             $cookieConfig = new $cookieClass();
 
             $appOptions = $appConfig['cookie_consent'];
@@ -77,14 +76,14 @@ class CookieConsentServiceProvider implements ServiceProviderInterface
             }
 
             return $cookieConfig;
-        };
+        });
 
-        $container['cookie-consent'] = function (Container $container) {
+        $container->set('cookie-consent', function (ContainerInterface $container) {
             return new CookieConsentManager(
-                $container['cookie-consent/config']->getPluginConfig(),
-                $container['cookie-consent/repository/disclosure'],
-                $container['translator']
+                $container->get('cookie-consent/config')->getPluginConfig(),
+                $container->get('cookie-consent/repository/disclosure'),
+                $container->get('translator')
             );
-        };
+        });
     }
 }

--- a/src/Charcoal/CookieConsent/CookieConsentServiceProvider.php
+++ b/src/Charcoal/CookieConsent/CookieConsentServiceProvider.php
@@ -29,7 +29,7 @@ class CookieConsentServiceProvider
          * @return Repository\DisclosureRepository<Model\Disclosure>
          */
         $container->set('cookie-consent/repository/disclosure', function (ContainerInterface $container) {
-            $collectionLoader = $container->get('model/collection/loader');
+            $collectionLoader = clone $container->get('model/collection/loader');
             $collectionLoader->setModel($container->get('cookie-consent/class-map')['model/disclosure']);
             $collectionLoader->setCollectionClass('array');
 
@@ -40,7 +40,7 @@ class CookieConsentServiceProvider
          * @return Repository\CategoryRepository<Model\Category>
          */
         $container->set('cookie-consent/repository/category', function (ContainerInterface $container) {
-            $collectionLoader = $container->get('model/collection/loader');
+            $collectionLoader = clone $container->get('model/collection/loader');
             $collectionLoader->setModel($container->get('cookie-consent/class-map')['model/category']);
             $collectionLoader->setCollectionClass('array');
 
@@ -51,7 +51,7 @@ class CookieConsentServiceProvider
          * @return Repository\LinkRelationRepository<\Charcoal\Model\Modelinterface>
          */
         $container->set('cookie-consent/repository/link-relation', function (ContainerInterface $container) {
-            $collectionLoader = $container->get('model/collection/loader');
+            $collectionLoader = clone $container->get('model/collection/loader');
             $collectionLoader->setModel($container->get('cookie-consent/config')->getPrivacyPolicyObjType());
             $collectionLoader->setCollectionClass('array');
 

--- a/src/Charcoal/CookieConsent/HasCookieConsentTrait.php
+++ b/src/Charcoal/CookieConsent/HasCookieConsentTrait.php
@@ -69,6 +69,10 @@ trait HasCookieConsentTrait
      */
     public function setCookieConsent($cookieConsent)
     {
-        $this->cookieConsent = $cookieConsent instanceof ContainerInterface ? $cookieConsent['cookie-consent'] : $cookieConsent;
+        $this->cookieConsent = $cookieConsent;
+
+        if ($cookieConsent instanceof ContainerInterface) {
+            $this->cookieConsent = $cookieConsent['cookie-consent'];
+        }
     }
 }

--- a/src/Charcoal/CookieConsent/HasCookieConsentTrait.php
+++ b/src/Charcoal/CookieConsent/HasCookieConsentTrait.php
@@ -2,7 +2,7 @@
 
 namespace Charcoal\CookieConsent;
 
-use Pimple\Container;
+use Psr\Container\ContainerInterface;
 
 /**
  * Provides templating tools for cookie consent integration
@@ -64,11 +64,11 @@ trait HasCookieConsentTrait
     }
 
     /**
-     * @param Container|CookieConsentManager $cookieConsent
+     * @param ContainerInterface|CookieConsentManager $cookieConsent
      * @return void
      */
     public function setCookieConsent($cookieConsent)
     {
-        $this->cookieConsent = $cookieConsent instanceof Container ? $cookieConsent['cookie-consent'] : $cookieConsent;
+        $this->cookieConsent = $cookieConsent instanceof ContainerInterface ? $cookieConsent['cookie-consent'] : $cookieConsent;
     }
 }

--- a/src/Charcoal/CookieConsent/Model/Disclosure.php
+++ b/src/Charcoal/CookieConsent/Model/Disclosure.php
@@ -4,7 +4,7 @@ namespace Charcoal\CookieConsent\Model;
 
 use Charcoal\CookieConsent\Model\Repository\CategoryRepository;
 use Charcoal\Object\Content;
-use Pimple\Container;
+use Psr\Container\ContainerInterface;
 
 /**
  * Model: Cookies Disclosure
@@ -142,9 +142,9 @@ class Disclosure extends Content
         $this->categoryRepository = $repository;
     }
 
-    protected function setDependencies(Container $container)
+    protected function setDependencies(ContainerInterface $container)
     {
-        $this->setCategoryRepository($container['cookie-consent/repository/category']);
+        $this->setCategoryRepository($container->get('cookie-consent/repository/category'));
         parent::setDependencies($container);
     }
 }

--- a/src/Charcoal/CookieConsent/Model/Structure/Link.php
+++ b/src/Charcoal/CookieConsent/Model/Structure/Link.php
@@ -9,7 +9,7 @@ use Charcoal\Property\Structure\StructureModel;
 use Charcoal\Translator\TranslatorAwareTrait;
 use Charcoal\Translator\Translation;
 use Charcoal\Validator\ValidatorInterface;
-use Pimple\Container;
+use Psr\Container\ContainerInterface;
 
 /**
  * Structure Model: Link
@@ -255,7 +255,7 @@ class Link extends StructureModel
     /**
      * {@inheritdoc}
      */
-    public function validate(ValidatorInterface &$v = null)
+    public function validate(?ValidatorInterface &$v = null)
     {
         return parent::validate($v) &&
             $this->validateFilePath() &&
@@ -313,10 +313,10 @@ class Link extends StructureModel
         $this->modelRepository = $repository;
     }
 
-    protected function setDependencies(Container $container)
+    protected function setDependencies(ContainerInterface $container)
     {
-        $this->setTranslator($container['translator']);
-        $this->setModelRepository($container['cookie-consent/repository/link-relation']);
+        $this->setTranslator($container->get('translator'));
+        $this->setModelRepository($container->get('cookie-consent/repository/link-relation'));
         parent::setDependencies($container);
     }
 


### PR DESCRIPTION
This updates the phpunit dependency to be compatible with php 8 and updates DI Container usage to be compatible with PHP-DI.

This should still be compatible with php 5.6+ but may be incompatible with older charcoal versions (due to the migration from Pimple -> PHP-DI)